### PR TITLE
Add sweep subcommand for full-coverage counter profiling

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,25 @@ pub enum Commands {
         #[arg(last = true, required = true)]
         target: Vec<String>,
     },
+    /// Run the target repeatedly, each time with a different fixed batch of 4 counters,
+    /// until all available counters have been covered once.
+    Sweep {
+        /// Use library from specified file
+        #[arg(short, long)]
+        library: Option<PathBuf>,
+
+        /// Scheduler quantum in nanoseconds
+        #[arg(short, long, default_value_t = 10_000_000)]
+        quantum: u64,
+
+        /// Output JSON file for per-counter rates (golden rates format)
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Target program and arguments
+        #[arg(last = true, required = true)]
+        target: Vec<String>,
+    },
     /// Run simulation with golden (synthetic) counter rates
     Simulate {
         /// Event library JSON file (required, no perf fallback)

--- a/src/event_library.rs
+++ b/src/event_library.rs
@@ -9,7 +9,7 @@ use nom::{
 use serde::{Deserialize, Serialize};
 use std::str;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct EventLibrary {
     pub events: Vec<Event>,
 }

--- a/src/event_registry.rs
+++ b/src/event_registry.rs
@@ -33,4 +33,8 @@ impl EventRegistry {
     pub fn get_event_ids(&self) -> Vec<EventId> {
         (0..self.events.len() as u32).collect()
     }
+
+    pub fn get_event_name(&self, id: EventId) -> &str {
+        &self.events[id as usize].name
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,13 +7,14 @@ use saccade::hardware_backend::HardwareBackend;
 use saccade::oculomotor::Oculomotor;
 use saccade::perf::Perf;
 use saccade::scheduler::Scheduler;
+use saccade::scheduler::fixed::FixedScheduler;
 use saccade::scheduler::random::RandomScheduler;
 use saccade::scheduler::round_robin::RoundRobinScheduler;
 use saccade::syscalls;
 use saccade::virtual_backend::{GoldenRates, VirtualBackend};
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::BufReader;
+use std::io::{BufReader, BufWriter};
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 use std::thread;
@@ -115,6 +116,141 @@ fn main() -> std::io::Result<()> {
             debug!("Child process exited after {} loops.", loops);
 
             child.wait().unwrap();
+        }
+        Commands::Sweep {
+            library,
+            quantum,
+            output,
+            target,
+        } => {
+            let lib = match library {
+                Some(path) => {
+                    debug!("Loading event library from {:?}", path);
+                    let file = File::open(path)?;
+                    let reader = BufReader::new(file);
+                    serde_json::from_reader(reader)?
+                }
+                None => {
+                    debug!("Generating event library on the fly...");
+                    EventLibrary::from_bytes(&Perf::list()).unwrap()
+                }
+            };
+
+            let all_ids: Vec<u32> = (0..lib.events.len() as u32).collect();
+            let batches: Vec<Vec<u32>> = all_ids.chunks(4).map(|c| c.to_vec()).collect();
+            let num_batches = batches.len();
+            tracing::info!(
+                "Sweep: {} events across {} runs",
+                all_ids.len(),
+                num_batches
+            );
+
+            // Accumulate per-event rates across all runs: event_id -> (total_count, total_duration_ns)
+            let mut totals: HashMap<u32, (u64, u64)> = HashMap::new();
+
+            for (run_idx, batch) in batches.iter().enumerate() {
+                let registry = EventRegistry::new(lib.clone());
+                tracing::info!(
+                    "Sweep run {}/{}: counters {:?}",
+                    run_idx + 1,
+                    num_batches,
+                    batch
+                        .iter()
+                        .map(|&id| registry.get_event_name(id))
+                        .collect::<Vec<_>>()
+                );
+                let num_events = registry.get_event_ids().len();
+
+                let mut child = unsafe {
+                    Command::new(target[0].clone())
+                        .args(&target[1..])
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .pre_exec(syscalls::ptrace_traceme)
+                        .spawn()
+                        .expect("Failed to spawn child process")
+                };
+
+                let pid = child.id();
+                syscalls::wait_for_exec(pid)?;
+
+                let scheduler = FixedScheduler::new(batch.clone());
+
+                let logger = Logger::new(format!("saccade_sweep_{}.csv", run_idx), 256_000)?;
+                let logger_tx = logger.clone_sender().expect("Failed to get logger sender");
+                let backend = HardwareBackend::new(pid, registry, logger_tx)
+                    .expect("Failed to create hardware backend");
+
+                let mut oculomotor = Oculomotor::new(
+                    Box::new(backend),
+                    Box::new(scheduler),
+                    num_events,
+                    Some(logger),
+                );
+
+                syscalls::ptrace_detach(pid)?;
+
+                let quantum_dur = Duration::from_nanos(quantum);
+                while child
+                    .try_wait()
+                    .expect("Failed to wait for child")
+                    .is_none()
+                {
+                    oculomotor.step();
+                    thread::sleep(quantum_dur);
+                }
+                child.wait().unwrap();
+
+                // Extract rates for this batch's counters from VCS
+                let vcs = oculomotor.vcs();
+                for &id in batch {
+                    let est = &vcs.all_estimates()[id as usize];
+                    if est.sample_count > 0 {
+                        // Accumulate weighted by sample count as a proxy for duration
+                        let entry = totals.entry(id).or_insert((0, 0));
+                        // Store (weighted_rate_sum, sample_count) for averaging
+                        entry.0 += (est.rate * est.sample_count as f64) as u64;
+                        entry.1 += est.sample_count;
+                    }
+                }
+            }
+
+            // Build golden rates map: event_name -> mean rate (events/ns)
+            let mut rates: HashMap<String, f64> = HashMap::new();
+            {
+                let registry = EventRegistry::new(lib.clone());
+                for (&id, &(weighted_sum, count)) in &totals {
+                    if count > 0 {
+                        let name = registry.get_event_name(id).to_string();
+                        rates.insert(name, weighted_sum as f64 / count as f64);
+                    }
+                }
+            }
+
+            let golden = saccade::virtual_backend::GoldenRates {
+                rates,
+                noise_stddev: 0.0,
+                seed: None,
+            };
+
+            match output {
+                Some(path) => {
+                    let file = File::create(&path)?;
+                    let writer = BufWriter::new(file);
+                    serde_json::to_writer_pretty(writer, &golden)?;
+                    tracing::info!("Sweep complete. Rates written to {:?}", path);
+                }
+                None => {
+                    eprintln!("\n{:<50} {:<16}", "Event", "Rate (ev/ns)");
+                    eprintln!("{}", "-".repeat(68));
+                    let mut entries: Vec<_> = golden.rates.iter().collect();
+                    entries.sort_by(|a, b| a.0.cmp(b.0));
+                    for (name, rate) in entries {
+                        eprintln!("{:<50} {:.8}", name, rate);
+                    }
+                    tracing::info!("Sweep complete.");
+                }
+            }
         }
         Commands::Simulate {
             library,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,4 +1,5 @@
 pub mod distribution;
+pub mod fixed;
 pub mod random;
 pub mod round_robin;
 pub mod test;

--- a/src/scheduler/fixed.rs
+++ b/src/scheduler/fixed.rs
@@ -1,0 +1,26 @@
+use crate::event_registry::EventId;
+use crate::scheduler::{ScheduleDecision, Scheduler};
+use crate::virtual_counter::VirtualCounterState;
+
+/// A scheduler that always returns the same fixed set of counters.
+/// Used by the `sweep` command to hold counters constant for an entire run.
+pub struct FixedScheduler {
+    active: Vec<EventId>,
+}
+
+impl FixedScheduler {
+    pub fn new(active: Vec<EventId>) -> Self {
+        Self { active }
+    }
+}
+
+impl Scheduler for FixedScheduler {
+    fn init(&mut self, _all_events: Vec<EventId>) {}
+
+    fn next_step(&mut self, _state: &VirtualCounterState) -> ScheduleDecision {
+        ScheduleDecision {
+            active_events: self.active.clone(),
+            duration: None,
+        }
+    }
+}

--- a/src/virtual_backend.rs
+++ b/src/virtual_backend.rs
@@ -3,11 +3,11 @@ use crate::event_registry::EventId;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand_distr::{Distribution, Normal};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::mpsc::SyncSender;
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GoldenRates {
     pub rates: HashMap<String, f64>,
     #[serde(default)]


### PR DESCRIPTION
Closes #32

## Summary

- Adds a `sweep` subcommand that runs the target `ceil(N/4)` times, each with a different fixed batch of 4 hardware counters, until all available events are covered
- Output is a golden-rates JSON file (compatible with `simulate --golden`) containing measured rates for every counter
- Target stdout/stderr is suppressed during sweep runs so only saccade's progress messages are visible

## Implementation

- `FixedScheduler` — new scheduler that holds a constant counter set for an entire run, bypassing the normal rotation logic
- `EventLibrary` derives `Clone` to support creating a fresh `EventRegistry` per run (required since `HardwareBackend` takes ownership)
- `GoldenRates` derives `Serialize` so sweep output can be written to JSON and fed back into `simulate`
- `get_event_name()` added to `EventRegistry` for human-readable progress logging

## Test plan

- `cargo test` passes
- `cargo clippy` clean
- Manual: `sudo ./target/debug/saccade sweep -o golden.json -- <benchmark>` produces a valid JSON file
- Round-trip: `cargo run -- simulate -l event_lib.json -g golden.json` runs without error