### PR TITLE
Multithreaded support: track TID/TGID and emit per-thread counter tracks

### DIFF
--- a/src/bpf/sampler.bpf.c
+++ b/src/bpf/sampler.bpf.c
@@ -6,7 +6,7 @@
 
 // Global variables for control (placed in .bss by default which is map-based in libbpf-rs)
 volatile __u64 min_sample_interval_ns = 1000000; // 1ms default
-volatile __u32 target_pid = 0;
+volatile __u32 target_tgid = 0;
 volatile __u32 active_counter_ids[MAX_COUNTERS] = {0};
 volatile bool tracking = false;
 volatile bool stopped[MAX_CPUS] = {[0 ... MAX_CPUS - 1] = true};
@@ -96,7 +96,8 @@ record_sample(__u32 pid, __u32 tgid, __u64 now, __u64 delta, __u32 type) {
 
     s->timestamp_ns = now;
     s->duration_ns = delta;
-    s->pid = pid;
+    s->pid = tgid;
+    s->tid = pid;
     s->cpu_id = bpf_get_smp_processor_id();
     s->type = type;
     bpf_get_current_comm(&s->task, sizeof(s->task));
@@ -159,7 +160,7 @@ int handle__sched_switch(u64 *ctx) {
         // no longer on-CPU so leaving it would produce a bogus sample).
         bpf_map_delete_elem(&start_map, &prev_pid);
         // Still handle switch-in for next.
-        if (target_pid != 0 && next_pid != target_pid)
+        if (target_tgid != 0 && next->tgid != target_tgid)
             return 0;
         bpf_map_update_elem(&start_map, &next_pid, &now, BPF_ANY);
         return 0;
@@ -175,7 +176,7 @@ int handle__sched_switch(u64 *ctx) {
     }
 
     // Handle Switch-IN (next)
-    if (target_pid != 0 && next_pid != target_pid) {
+    if (target_tgid != 0 && next->tgid != target_tgid) {
         return 0;
     }
 
@@ -189,15 +190,16 @@ SEC("perf_event")
 int handle_timer(struct bpf_perf_event_data *ctx) {
     u64 cpu_id = bpf_get_smp_processor_id();
     u64 now = bpf_ktime_get_ns();
-    u32 pid = bpf_get_current_pid_tgid() >> 32;
-    u32 tgid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 tgid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
 
     if (!tracking) {
         set_stopped(cpu_id, true);
         return 0;
     }
 
-    if (handle_resume(cpu_id, pid, now)) {
+    if (handle_resume(cpu_id, tid, now)) {
         return 0; // Resumed — baseline reset, no sample
     }
     set_stopped(cpu_id, false);
@@ -205,7 +207,7 @@ int handle_timer(struct bpf_perf_event_data *ctx) {
     // This hook fires periodically (e.g. 100Hz) on each CPU.
     // Check if the CURRENT task is being tracked.
 
-    u64 *tsp = bpf_map_lookup_elem(&start_map, &pid);
+    u64 *tsp = bpf_map_lookup_elem(&start_map, &tid);
     if (!tsp) {
         // Not tracking this task (or not switched in via hook)
         return 0;
@@ -220,10 +222,10 @@ int handle_timer(struct bpf_perf_event_data *ctx) {
 
     // Record Intermediate Sample based on delta since last time
     // Capture delta since last sample.
-    record_sample(pid, tgid, now, delta, SAMPLE_TYPE_INTERMEDIATE);
+    record_sample(tid, tgid, now, delta, SAMPLE_TYPE_INTERMEDIATE);
 
     // Update timestamp so next delta is relative to now
-    bpf_map_update_elem(&start_map, &pid, &now, BPF_EXIST);
+    bpf_map_update_elem(&start_map, &tid, &now, BPF_EXIST);
 
     return 0;
 }

--- a/src/bpf/sampler.h
+++ b/src/bpf/sampler.h
@@ -21,7 +21,7 @@ struct saccade_sample {
     __u32 pid;
     __u32 cpu_id;
     __u32 type;
-    __u32 pad0; // Explicit padding for alignment
+    __u32 tid;                    // Kernel thread ID (task_struct->pid); pid field holds TGID
     __u64 counters[MAX_COUNTERS]; // absolute perf counter readings (not deltas)
     __u64 events[MAX_COUNTERS];
     char task[TASK_COMM_LEN];

--- a/src/commands/simulate.rs
+++ b/src/commands/simulate.rs
@@ -33,11 +33,17 @@ pub fn simulate(
     debug!("Loading rate time-series from {:?}", rates_trace);
     let timeseries = perfetto::read_rate_timeseries(&rates_trace)?;
 
-    let mut series_map: HashMap<u32, Vec<(u64, f64)>> = HashMap::new();
-    for (name, data) in timeseries.series {
+    let mut series_map: HashMap<(u32, u32), Vec<(u64, f64)>> = HashMap::new();
+    for ((name, tid), data) in timeseries.series {
         if let Some(id) = registry.lookup(&name) {
-            debug!("Rate series: {} (id={}) -> {} points", name, id, data.len());
-            series_map.insert(id, data);
+            debug!(
+                "Rate series: {} tid={} (id={}) -> {} points",
+                name,
+                tid,
+                id,
+                data.len()
+            );
+            series_map.insert((id, tid), data);
         } else {
             tracing::warn!("Unknown event in rates trace: {}", name);
         }

--- a/src/commands/sweep.rs
+++ b/src/commands/sweep.rs
@@ -1,6 +1,7 @@
 use crate::commands::load_library;
 use crate::event::EventRegistry;
 use crate::perfetto::PerfettoWriter;
+use crate::sample::TASK_COMM_LEN;
 use crate::source::SampleSource;
 use crate::source::hardware::HardwareSampleSource;
 use crate::syscalls;
@@ -89,7 +90,6 @@ pub fn sweep(
         {
             let (raw_samples, _elapsed_ns) = source.collect();
             for s in raw_samples {
-                use crate::sample::TASK_COMM_LEN;
                 assert_ne!(s.duration_ns, 0);
                 let t0 = *batch_t0.get_or_insert(s.timestamp_ns);
                 let rel_ts = s.timestamp_ns.saturating_sub(t0);

--- a/src/commands/sweep.rs
+++ b/src/commands/sweep.rs
@@ -27,8 +27,15 @@ pub fn sweep(
         num_batches
     );
 
-    // event_id -> Vec<(timestamp_ns, rate)>
-    let mut all_series: HashMap<u32, Vec<(u64, f64)>> = HashMap::new();
+    // (event_id, synthetic_tid) -> Vec<(timestamp_ns, rate)>
+    let mut all_series: HashMap<(u32, u32), Vec<(u64, f64)>> = HashMap::new();
+    // synthetic_tid -> (0, task_name)  [tgid=0: single synthetic process for whole sweep]
+    let mut thread_meta: HashMap<u32, (u32, String)> = HashMap::new();
+    // Global across batches: (task_name, within_name_idx) -> synthetic_tid
+    // The n-th thread with a given name in a batch maps to the same synthetic TID across
+    // all batches, aligning threads by birth-order for deterministic workloads.
+    let mut name_idx_to_synthetic: HashMap<(String, u32), u32> = HashMap::new();
+    let mut next_synthetic_tid: u32 = 1;
 
     let pb = ProgressBar::new(num_batches as u64);
     pb.set_style(
@@ -69,6 +76,10 @@ pub fn sweep(
             .expect("Failed to apply schedule");
         syscalls::ptrace_detach(pid)?;
 
+        // Per-batch state: reset each run so TID numbering restarts from 0 per name.
+        let mut batch_real_to_synthetic: HashMap<u32, u32> = HashMap::new();
+        let mut batch_name_counters: HashMap<String, u32> = HashMap::new();
+
         let quantum_dur = Duration::from_nanos(quantum);
         let mut batch_t0: Option<u64> = None;
         while child
@@ -78,13 +89,37 @@ pub fn sweep(
         {
             let (raw_samples, _elapsed_ns) = source.collect();
             for s in raw_samples {
+                use crate::sample::TASK_COMM_LEN;
                 assert_ne!(s.duration_ns, 0);
                 let t0 = *batch_t0.get_or_insert(s.timestamp_ns);
                 let rel_ts = s.timestamp_ns.saturating_sub(t0);
+
+                // Normalize thread identity by (task_name, birth_order_within_name).
+                // batch_real_to_synthetic caches within a batch; name_idx_to_synthetic
+                // is the stable global mapping that aligns threads across batches.
+                let task_len = s.task.iter().position(|&c| c == 0).unwrap_or(TASK_COMM_LEN);
+                let task_name = String::from_utf8_lossy(&s.task[..task_len]).into_owned();
+                let synthetic_tid = *batch_real_to_synthetic.entry(s.tid).or_insert_with(|| {
+                    let counter = batch_name_counters.entry(task_name.clone()).or_insert(0);
+                    let within_name_idx = *counter;
+                    *counter += 1;
+                    *name_idx_to_synthetic
+                        .entry((task_name.clone(), within_name_idx))
+                        .or_insert_with(|| {
+                            let id = next_synthetic_tid;
+                            next_synthetic_tid += 1;
+                            id
+                        })
+                });
+
                 all_series
-                    .entry(s.event_id)
+                    .entry((s.event_id, synthetic_tid))
                     .or_default()
                     .push((rel_ts, s.count as f64 / s.duration_ns as f64));
+                // tgid=0: all batches share one synthetic process in the trace
+                thread_meta
+                    .entry(synthetic_tid)
+                    .or_insert((0u32, task_name));
             }
             thread::sleep(quantum_dur);
         }
@@ -100,8 +135,7 @@ pub fn sweep(
                 .map(|id| registry.get_event_name(id).to_string())
                 .collect();
             let mut writer = PerfettoWriter::new(&path, event_names)?;
-            writer.register_tracks()?;
-            writer.write_raw_series(&all_series)?;
+            writer.write_raw_series(&all_series, &thread_meta)?;
             writer.flush()?;
             tracing::info!("Sweep complete. Trace written to {:?}", path);
         }

--- a/src/docs/design_data_structures.rs
+++ b/src/docs/design_data_structures.rs
@@ -60,7 +60,7 @@
 //! // In sampler.bpf.c
 //!
 //! volatile __u64 min_sample_interval_ns = 1000000; // Default 1ms
-//! volatile __u32 target_pid = 0;
+//! volatile __u32 target_tgid = 0;
 //! volatile __u32 active_counter_ids[MAX_COUNTERS] = {0, 0, 0, 0};
 //! ```
 //!

--- a/src/perfetto/reader.rs
+++ b/src/perfetto/reader.rs
@@ -3,47 +3,82 @@ use std::collections::HashMap;
 use std::io;
 use std::path::Path;
 
-/// Per-event time-series of rates, keyed by event name.
+/// Per-(event, thread) time-series of rates.
+/// Key: (event_name, tid). For traces with no thread info, tid = 0.
 /// Each entry is a sorted Vec of (timestamp_ns, rate_events_per_ns).
 pub struct RateTimeSeries {
-    pub series: HashMap<String, Vec<(u64, f64)>>,
+    pub series: HashMap<(String, u32), Vec<(u64, f64)>>,
 }
 
 /// Parse a `.perfetto-trace` written by `PerfettoWriter` and extract
-/// the rate time-series for each event.
+/// per-thread rate time-series for each event.
 ///
-/// Track names are expected to follow the `{event_name}/rate` convention.
+/// Handles two track name formats:
+/// - New: counter track named `{event_name}/rate` with `parent_uuid` pointing to a thread track
+///        (thread track has a `ThreadDescriptor` with a `tid` field) → key = (event_name, tid)
+/// - Old: counter track named `{event_name}/rate` with no thread parent → key = (event_name, 0)
+///
 /// `{event_name}/uncertainty` tracks are ignored.
 pub fn read_rate_timeseries(path: impl AsRef<Path>) -> io::Result<RateTimeSeries> {
     let data = std::fs::read(path)?;
     let packets = read_trace_packets(&data)?;
 
-    // Pass 1: build uuid -> event_name from TrackDescriptor packets.
-    let mut uuid_to_name: HashMap<u64, String> = HashMap::new();
+    // Pass 1: scan TrackDescriptors.
+    //   - uuid_to_tid: uuid → tid, for tracks that have a ThreadDescriptor
+    //   - uuid_to_rate_key: uuid → (event_name, parent_uuid) for rate counter tracks
+    let mut uuid_to_tid: HashMap<u64, u32> = HashMap::new();
+    let mut uuid_to_rate_key: HashMap<u64, (String, Option<u64>)> = HashMap::new();
+
     for packet in &packets {
-        if packet.has_track_descriptor() {
-            let desc = packet.track_descriptor();
-            let name = desc.name().to_string();
-            if let Some(event_name) = name.strip_suffix("/rate") {
-                uuid_to_name.insert(desc.uuid(), event_name.to_string());
-            }
+        if !packet.has_track_descriptor() {
+            continue;
+        }
+        let desc = packet.track_descriptor();
+        let uuid = desc.uuid();
+        let name = desc.name().to_string();
+
+        // Detect thread tracks via ThreadDescriptor.
+        if let Some(thread) = desc.thread.as_ref() {
+            let tid = thread.tid() as u32;
+            uuid_to_tid.insert(uuid, tid);
+        }
+
+        // Detect rate counter tracks by name suffix.
+        if let Some(event_name) = name.strip_suffix("/rate") {
+            let parent_uuid = if desc.has_parent_uuid() {
+                Some(desc.parent_uuid())
+            } else {
+                None
+            };
+            uuid_to_rate_key.insert(uuid, (event_name.to_string(), parent_uuid));
         }
     }
 
-    // Pass 2: collect counter values from TrackEvent packets.
-    let mut series: HashMap<String, Vec<(u64, f64)>> = HashMap::new();
+    // Pass 2: for each rate counter track, resolve its tid via parent_uuid.
+    //   If the parent is a thread track, use its tid; otherwise tid = 0.
+    let mut uuid_to_event_tid: HashMap<u64, (String, u32)> = HashMap::new();
+    for (uuid, (event_name, parent_uuid)) in &uuid_to_rate_key {
+        let tid = parent_uuid
+            .and_then(|p| uuid_to_tid.get(&p))
+            .copied()
+            .unwrap_or(0);
+        uuid_to_event_tid.insert(*uuid, (event_name.clone(), tid));
+    }
+
+    // Pass 3: collect counter values from TrackEvent packets.
+    let mut series: HashMap<(String, u32), Vec<(u64, f64)>> = HashMap::new();
     for packet in &packets {
         if !packet.has_track_event() {
             continue;
         }
         let event = packet.track_event();
-        let Some(event_name) = uuid_to_name.get(&event.track_uuid()) else {
+        let Some((event_name, tid)) = uuid_to_event_tid.get(&event.track_uuid()) else {
             continue;
         };
         let timestamp = packet.timestamp();
         let rate = event.double_counter_value();
         series
-            .entry(event_name.clone())
+            .entry((event_name.clone(), *tid))
             .or_default()
             .push((timestamp, rate));
     }

--- a/src/perfetto/reader.rs
+++ b/src/perfetto/reader.rs
@@ -15,7 +15,7 @@ pub struct RateTimeSeries {
 ///
 /// Handles two track name formats:
 /// - New: counter track named `{event_name}/rate` with `parent_uuid` pointing to a thread track
-///        (thread track has a `ThreadDescriptor` with a `tid` field) → key = (event_name, tid)
+///   (thread track has a `ThreadDescriptor` with a `tid` field) → key = (event_name, tid)
 /// - Old: counter track named `{event_name}/rate` with no thread parent → key = (event_name, 0)
 ///
 /// `{event_name}/uncertainty` tracks are ignored.

--- a/src/perfetto/trace.rs
+++ b/src/perfetto/trace.rs
@@ -130,7 +130,17 @@ impl PerfettoWriter {
         if let Some(&uuid) = self.thread_uuids.get(&tid) {
             return Ok(uuid);
         }
-        let process_uuid = self.ensure_process_track(tgid, task)?;
+        // Use the thread's task name as the process name only when this is the main thread
+        // (tid == tgid). Otherwise fall back to a numeric name so that the process track is
+        // not accidentally labeled with an arbitrary worker thread's comm string.
+        let process_name;
+        let process_name_str: &str = if tid == tgid {
+            task
+        } else {
+            process_name = format!("{}", tgid);
+            &process_name
+        };
+        let process_uuid = self.ensure_process_track(tgid, process_name_str)?;
         let uuid = self.next_thread_uuid;
         self.next_thread_uuid += 1;
         self.thread_uuids.insert(tid, uuid);
@@ -279,10 +289,10 @@ impl PerfettoWriter {
 
         for (ts, event_id, tid, rate) in points {
             let (tgid, task) = match thread_meta.get(&tid) {
-                Some(m) => (m.0, m.1.clone()),
+                Some(m) => (m.0, m.1.as_str()),
                 None => continue,
             };
-            let thread_uuid = self.ensure_thread_track(tgid, tid, &task)?;
+            let thread_uuid = self.ensure_thread_track(tgid, tid, task)?;
             let (r_uuid, u_uuid) = self.ensure_thread_counter_tracks(tid, event_id, thread_uuid)?;
             self.write_counter_packet(ts, r_uuid, rate)?;
             self.write_counter_packet(ts, u_uuid, 0.0)?;

--- a/src/perfetto/trace.rs
+++ b/src/perfetto/trace.rs
@@ -1,6 +1,9 @@
 use crate::event::EventId;
+use crate::quantum::EventAggregate;
 use crate::virtual_counter::VirtualCounterState;
 use perfetto_protos::counter_descriptor::CounterDescriptor;
+use perfetto_protos::process_descriptor::ProcessDescriptor;
+use perfetto_protos::thread_descriptor::ThreadDescriptor;
 use perfetto_protos::trace_packet::TracePacket;
 use perfetto_protos::track_descriptor::TrackDescriptor;
 use perfetto_protos::track_event::TrackEvent;
@@ -12,6 +15,8 @@ use std::path::Path;
 
 /// UUID base offset to avoid UUID 0 (which is the implicit global track).
 const UUID_BASE: u64 = 1000;
+/// UUID base for dynamically-allocated per-thread tracks.
+const THREAD_UUID_BASE: u64 = 1_000_000;
 
 /// Writes Perfetto trace files containing VCS rate and uncertainty counter tracks.
 ///
@@ -20,6 +25,14 @@ const UUID_BASE: u64 = 1000;
 pub struct PerfettoWriter {
     writer: BufWriter<File>,
     event_names: Vec<String>,
+    /// Next UUID to allocate for per-thread tracks.
+    next_thread_uuid: u64,
+    /// tgid → process track uuid
+    process_uuids: HashMap<u32, u64>,
+    /// tid → thread track uuid
+    thread_uuids: HashMap<u32, u64>,
+    /// (tid, event_id) → (rate_uuid, uncertainty_uuid)
+    thread_counter_uuids: HashMap<(u32, u32), (u64, u64)>,
 }
 
 impl PerfettoWriter {
@@ -29,6 +42,10 @@ impl PerfettoWriter {
         Ok(Self {
             writer,
             event_names,
+            next_thread_uuid: THREAD_UUID_BASE,
+            process_uuids: HashMap::new(),
+            thread_uuids: HashMap::new(),
+            thread_counter_uuids: HashMap::new(),
         })
     }
 
@@ -86,6 +103,117 @@ impl PerfettoWriter {
         Ok(())
     }
 
+    /// Lazily allocate a UUID for a process track; emit TrackDescriptor on first call.
+    fn ensure_process_track(&mut self, tgid: u32, name: &str) -> std::io::Result<u64> {
+        if let Some(&uuid) = self.process_uuids.get(&tgid) {
+            return Ok(uuid);
+        }
+        let uuid = self.next_thread_uuid;
+        self.next_thread_uuid += 1;
+        self.process_uuids.insert(tgid, uuid);
+
+        let mut proc_desc = ProcessDescriptor::new();
+        proc_desc.set_pid(tgid as i32);
+        proc_desc.set_process_name(name.to_string());
+
+        let mut desc = TrackDescriptor::new();
+        desc.set_uuid(uuid);
+        desc.set_name(name.to_string());
+        desc.process = protobuf::MessageField::some(proc_desc);
+
+        self.write_track_descriptor_packet(desc)?;
+        Ok(uuid)
+    }
+
+    /// Lazily allocate a UUID for a thread track; emit TrackDescriptor on first call.
+    fn ensure_thread_track(&mut self, tgid: u32, tid: u32, task: &str) -> std::io::Result<u64> {
+        if let Some(&uuid) = self.thread_uuids.get(&tid) {
+            return Ok(uuid);
+        }
+        let process_uuid = self.ensure_process_track(tgid, task)?;
+        let uuid = self.next_thread_uuid;
+        self.next_thread_uuid += 1;
+        self.thread_uuids.insert(tid, uuid);
+
+        let mut thread_desc = ThreadDescriptor::new();
+        thread_desc.set_pid(tgid as i32);
+        thread_desc.set_tid(tid as i32);
+        thread_desc.set_thread_name(task.to_string());
+
+        let mut desc = TrackDescriptor::new();
+        desc.set_uuid(uuid);
+        desc.set_name(task.to_string());
+        desc.set_parent_uuid(process_uuid);
+        desc.thread = protobuf::MessageField::some(thread_desc);
+
+        self.write_track_descriptor_packet(desc)?;
+        Ok(uuid)
+    }
+
+    /// Lazily allocate UUIDs for per-thread rate/uncertainty counter tracks.
+    fn ensure_thread_counter_tracks(
+        &mut self,
+        tid: u32,
+        event_id: u32,
+        thread_uuid: u64,
+    ) -> std::io::Result<(u64, u64)> {
+        if let Some(&uuids) = self.thread_counter_uuids.get(&(tid, event_id)) {
+            return Ok(uuids);
+        }
+        let rate_uuid = self.next_thread_uuid;
+        self.next_thread_uuid += 1;
+        let uncertainty_uuid = self.next_thread_uuid;
+        self.next_thread_uuid += 1;
+        self.thread_counter_uuids
+            .insert((tid, event_id), (rate_uuid, uncertainty_uuid));
+
+        let event_name = self
+            .event_names
+            .get(event_id as usize)
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+
+        for (uuid, suffix, unit) in [
+            (rate_uuid, "rate", "events/ns"),
+            (uncertainty_uuid, "uncertainty", "uncertainty"),
+        ] {
+            let mut counter = CounterDescriptor::new();
+            counter.set_unit_name(unit.to_string());
+
+            let mut desc = TrackDescriptor::new();
+            desc.set_uuid(uuid);
+            desc.set_name(format!("{}/{}", event_name, suffix));
+            desc.set_parent_uuid(thread_uuid);
+            desc.counter = protobuf::MessageField::some(counter);
+
+            self.write_track_descriptor_packet(desc)?;
+        }
+        Ok((rate_uuid, uncertainty_uuid))
+    }
+
+    /// Emit per-thread counter values for a single quantum step.
+    ///
+    /// `thread_meta`: tid → (tgid, task_name) — needed to register process/thread tracks.
+    pub fn emit_thread_steps(
+        &mut self,
+        timestamp_ns: u64,
+        per_thread: &HashMap<(u32, EventId), EventAggregate>,
+        thread_meta: &HashMap<u32, (u32, String)>,
+    ) -> std::io::Result<()> {
+        for (&(tid, event_id), agg) in per_thread {
+            let (tgid, task) = match thread_meta.get(&tid) {
+                Some(m) => (m.0, m.1.as_str()),
+                None => continue,
+            };
+            let thread_uuid = self.ensure_thread_track(tgid, tid, task)?;
+            let (rate_uuid, uncert_uuid) =
+                self.ensure_thread_counter_tracks(tid, event_id, thread_uuid)?;
+            self.write_counter_packet(timestamp_ns, rate_uuid, agg.mean_rate)?;
+            self.write_counter_packet(timestamp_ns, uncert_uuid, agg.stddev_rate)?;
+        }
+        Ok(())
+    }
+
     fn write_track_descriptor_packet(&mut self, desc: TrackDescriptor) -> std::io::Result<()> {
         let mut packet = TracePacket::new();
         packet.set_track_descriptor(desc);
@@ -130,22 +258,34 @@ impl PerfettoWriter {
         Ok(())
     }
 
-    /// Write pre-collected time-series data as counter packets.
-    /// `series`: event_id → sorted Vec of (timestamp_ns, rate).
-    /// Emits rate and uncertainty (0.0 = observed) packets sorted by timestamp.
+    /// Write pre-collected per-thread time-series data as counter packets.
+    ///
+    /// `series`: (event_id, tid) → sorted Vec of (timestamp_ns, rate).
+    /// `thread_meta`: tid → (tgid, task_name) — used to register process/thread tracks.
+    /// Emits per-thread rate and uncertainty (0.0 = observed) packets sorted by timestamp.
     pub fn write_raw_series(
         &mut self,
-        series: &HashMap<u32, Vec<(u64, f64)>>,
+        series: &HashMap<(u32, u32), Vec<(u64, f64)>>,
+        thread_meta: &HashMap<u32, (u32, String)>,
     ) -> std::io::Result<()> {
-        let mut points: Vec<(u64, u32, f64)> = series
+        // Collect all points with their (event_id, tid) key, sorted by timestamp.
+        let mut points: Vec<(u64, u32, u32, f64)> = series
             .iter()
-            .flat_map(|(&id, pts)| pts.iter().map(move |&(ts, rate)| (ts, id, rate)))
+            .flat_map(|(&(event_id, tid), pts)| {
+                pts.iter().map(move |&(ts, rate)| (ts, event_id, tid, rate))
+            })
             .collect();
-        points.sort_unstable_by_key(|&(ts, _, _)| ts);
+        points.sort_unstable_by_key(|&(ts, _, _, _)| ts);
 
-        for (ts, id, rate) in points {
-            self.write_counter_packet(ts, rate_uuid(id), rate)?;
-            self.write_counter_packet(ts, uncertainty_uuid(id), 0.0)?;
+        for (ts, event_id, tid, rate) in points {
+            let (tgid, task) = match thread_meta.get(&tid) {
+                Some(m) => (m.0, m.1.clone()),
+                None => continue,
+            };
+            let thread_uuid = self.ensure_thread_track(tgid, tid, &task)?;
+            let (r_uuid, u_uuid) = self.ensure_thread_counter_tracks(tid, event_id, thread_uuid)?;
+            self.write_counter_packet(ts, r_uuid, rate)?;
+            self.write_counter_packet(ts, u_uuid, 0.0)?;
         }
         Ok(())
     }

--- a/src/quantum.rs
+++ b/src/quantum.rs
@@ -31,6 +31,7 @@ pub struct Quantum {
     timestamp_ns: u64,
     elapsed_ns: u64,
     aggregates: OnceCell<HashMap<EventId, EventAggregate>>,
+    per_thread_aggregates: OnceCell<HashMap<(u32, EventId), EventAggregate>>,
 }
 
 impl Quantum {
@@ -40,6 +41,7 @@ impl Quantum {
             timestamp_ns,
             elapsed_ns,
             aggregates: OnceCell::new(),
+            per_thread_aggregates: OnceCell::new(),
         }
     }
 
@@ -66,6 +68,78 @@ impl Quantum {
     pub fn observed_events(&self) -> Vec<EventId> {
         self.aggregates().keys().copied().collect()
     }
+
+    /// Lazily compute per-(tid, event) rate aggregates. Result is cached.
+    pub fn per_thread_aggregates(&self) -> &HashMap<(u32, EventId), EventAggregate> {
+        self.per_thread_aggregates
+            .get_or_init(|| aggregate_samples_by_thread(&self.samples))
+    }
+}
+
+/// Welford's online algorithm keyed by (tid, event_id).
+fn aggregate_samples_by_thread(samples: &[RawSample]) -> HashMap<(u32, EventId), EventAggregate> {
+    struct Acc {
+        n: u32,
+        mean: f64,
+        m2: f64,
+        min: f64,
+        max: f64,
+        total_count: u64,
+        total_duration_ns: u64,
+    }
+
+    let mut by_thread_event: HashMap<(u32, EventId), Acc> = HashMap::new();
+
+    for s in samples {
+        if s.duration_ns == 0 {
+            continue;
+        }
+        let rate = s.count as f64 / s.duration_ns as f64;
+        let acc = by_thread_event.entry((s.tid, s.event_id)).or_insert(Acc {
+            n: 0,
+            mean: 0.0,
+            m2: 0.0,
+            min: f64::MAX,
+            max: f64::MIN,
+            total_count: 0,
+            total_duration_ns: 0,
+        });
+        acc.n += 1;
+        let delta = rate - acc.mean;
+        acc.mean += delta / acc.n as f64;
+        acc.m2 += delta * (rate - acc.mean);
+        if rate < acc.min {
+            acc.min = rate;
+        }
+        if rate > acc.max {
+            acc.max = rate;
+        }
+        acc.total_count += s.count;
+        acc.total_duration_ns += s.duration_ns;
+    }
+
+    by_thread_event
+        .into_iter()
+        .map(|((tid, event_id), acc)| {
+            (
+                (tid, event_id),
+                EventAggregate {
+                    event_id,
+                    total_count: acc.total_count,
+                    total_duration_ns: acc.total_duration_ns,
+                    mean_rate: acc.mean,
+                    stddev_rate: if acc.n < 2 {
+                        0.0
+                    } else {
+                        (acc.m2 / acc.n as f64).sqrt()
+                    },
+                    min_rate: if acc.n == 0 { 0.0 } else { acc.min },
+                    max_rate: if acc.n == 0 { 0.0 } else { acc.max },
+                    num_samples: acc.n,
+                },
+            )
+        })
+        .collect()
 }
 
 /// Welford's online algorithm over per-sample rates (count / duration_ns).

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -28,7 +28,7 @@ pub struct WireSample {
     pub pid: u32,
     pub cpu_id: u32,
     pub type_: u32,
-    pub pad: u32,
+    pub tid: u32,
     pub counters: [u64; MAX_COUNTERS], // absolute perf counter readings
     pub events: [u64; MAX_COUNTERS],   // active event IDs per slot
     pub task: [u8; TASK_COMM_LEN],
@@ -47,6 +47,7 @@ pub struct RawSample {
     pub duration_ns: u64,
     pub cpu_id: u32,
     pub pid: u32,
+    pub tid: u32,
     /// The hardware event that was counted.
     pub event_id: EventId,
     /// Number of events that occurred during `duration_ns`. This is a delta, not an absolute value.

--- a/src/sink/csv.rs
+++ b/src/sink/csv.rs
@@ -18,7 +18,7 @@ impl CsvSink {
         let mut writer = BufWriter::with_capacity(8 * 1024 * 1024, file);
         writeln!(
             writer,
-            "timestamp_ns,duration_ns,cpu_id,pid,event_id,count,task"
+            "timestamp_ns,duration_ns,cpu_id,pid,tid,event_id,count,task"
         )?;
         Ok(Self { writer })
     }
@@ -36,8 +36,15 @@ impl OutputSink for CsvSink {
             let task_name = String::from_utf8_lossy(&s.task[..task_len]);
             writeln!(
                 self.writer,
-                "{},{},{},{},{},{},{}",
-                s.timestamp_ns, s.duration_ns, s.cpu_id, s.pid, s.event_id, s.count, task_name,
+                "{},{},{},{},{},{},{},{}",
+                s.timestamp_ns,
+                s.duration_ns,
+                s.cpu_id,
+                s.pid,
+                s.tid,
+                s.event_id,
+                s.count,
+                task_name,
             )?;
         }
         Ok(())

--- a/src/sink/perfetto.rs
+++ b/src/sink/perfetto.rs
@@ -1,20 +1,27 @@
 use crate::event::EventId;
 use crate::perfetto::PerfettoWriter;
 use crate::quantum::Quantum;
+use crate::sample::TASK_COMM_LEN;
 use crate::sink::OutputSink;
 use crate::virtual_counter::VirtualCounterState;
+use std::collections::HashMap;
 use std::path::Path;
 
-/// Perfetto trace sink. Emits VCS rate and uncertainty counter tracks.
+/// Perfetto trace sink. Emits VCS rate/uncertainty aggregate tracks plus per-thread counter tracks.
 pub struct PerfettoSink {
     writer: PerfettoWriter,
+    /// tid → (tgid, task_name) — accumulated across quantums for track registration.
+    thread_meta: HashMap<u32, (u32, String)>,
 }
 
 impl PerfettoSink {
     pub fn new(path: impl AsRef<Path>, event_names: Vec<String>) -> std::io::Result<Self> {
         let mut writer = PerfettoWriter::new(path, event_names)?;
         writer.register_tracks()?;
-        Ok(Self { writer })
+        Ok(Self {
+            writer,
+            thread_meta: HashMap::new(),
+        })
     }
 }
 
@@ -25,8 +32,28 @@ impl OutputSink for PerfettoSink {
         vcs: &VirtualCounterState,
         active_set: &[EventId],
     ) -> std::io::Result<()> {
+        // Update thread metadata from this quantum's raw samples.
+        for s in quantum.samples() {
+            if s.tid == 0 {
+                continue;
+            }
+            self.thread_meta.entry(s.tid).or_insert_with(|| {
+                let task_len = s.task.iter().position(|&c| c == 0).unwrap_or(TASK_COMM_LEN);
+                let task_name = String::from_utf8_lossy(&s.task[..task_len]).into_owned();
+                (s.pid, task_name)
+            });
+        }
+
+        // Emit aggregate VCS tracks (unchanged).
         self.writer
-            .emit_step(quantum.timestamp_ns(), vcs, active_set)
+            .emit_step(quantum.timestamp_ns(), vcs, active_set)?;
+
+        // Emit per-thread counter tracks.
+        self.writer.emit_thread_steps(
+            quantum.timestamp_ns(),
+            quantum.per_thread_aggregates(),
+            &self.thread_meta,
+        )
     }
 
     fn finish(&mut self) -> std::io::Result<()> {

--- a/src/sink/perfetto.rs
+++ b/src/sink/perfetto.rs
@@ -33,6 +33,7 @@ impl OutputSink for PerfettoSink {
         active_set: &[EventId],
     ) -> std::io::Result<()> {
         // Update thread metadata from this quantum's raw samples.
+        // tid=0 is the kernel idle task; it is never a meaningful profiling target.
         for s in quantum.samples() {
             if s.tid == 0 {
                 continue;

--- a/src/source/hardware.rs
+++ b/src/source/hardware.rs
@@ -33,7 +33,7 @@ pub struct HardwareSampleSource {
 
 impl HardwareSampleSource {
     pub fn new(
-        target_pid: u32,
+        target_tgid: u32,
         registry: EventRegistry,
         logger_tx: Option<SyncSender<WireSample>>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
@@ -47,8 +47,8 @@ impl HardwareSampleSource {
             .maps
             .bss_data
             .as_mut()
-            .expect("Failed to set target PID")
-            .target_tgid = target_pid;
+            .expect("Failed to set target TGID")
+            .target_tgid = target_tgid;
         open_skel
             .maps
             .data_data
@@ -59,7 +59,7 @@ impl HardwareSampleSource {
         let mut skel = open_skel.load()?;
         skel.attach()?;
 
-        debug!("HardwareSampleSource attached to PID {}", target_pid);
+        debug!("HardwareSampleSource attached to TGID {}", target_tgid);
 
         let (wire_tx, wire_rx) = mpsc::sync_channel::<WireSample>(256_000);
 

--- a/src/source/hardware.rs
+++ b/src/source/hardware.rs
@@ -195,18 +195,23 @@ impl SampleSource for HardwareSampleSource {
         if old_set.is_empty() {
             for (i, &id) in new_set.iter().enumerate() {
                 self.hw_counters.update_slot(&mut self.skel, i, id)?;
+                for cpu_baselines in self.baselines.iter_mut() {
+                    cpu_baselines[i] = 0;
+                }
             }
         } else {
             for (i, &old_id) in old_set.iter().enumerate() {
                 if old_id != new_set[i] {
                     self.hw_counters
                         .update_slot(&mut self.skel, i, new_set[i])?;
+                    // Reset baseline only for this slot; the next RESUME marker
+                    // will re-anchor it from the current absolute counter value.
+                    for cpu_baselines in self.baselines.iter_mut() {
+                        cpu_baselines[i] = 0;
+                    }
                 }
             }
         }
-        // When counters are swapped, baselines are stale — reset them all.
-        // The next sample from each CPU will establish a new baseline via saturating_sub.
-        self.baselines = [[0u64; MAX_COUNTERS]; MAX_CPUS];
         Ok(())
     }
 

--- a/src/source/hardware.rs
+++ b/src/source/hardware.rs
@@ -48,7 +48,7 @@ impl HardwareSampleSource {
             .bss_data
             .as_mut()
             .expect("Failed to set target PID")
-            .target_pid = target_pid;
+            .target_tgid = target_pid;
         open_skel
             .maps
             .data_data
@@ -159,6 +159,7 @@ impl HardwareSampleSource {
                 duration_ns: wire.duration_ns,
                 cpu_id: wire.cpu_id,
                 pid: wire.pid,
+                tid: wire.tid,
                 event_id,
                 count,
                 task: wire.task,

--- a/src/source/virtual_source.rs
+++ b/src/source/virtual_source.rs
@@ -9,7 +9,7 @@ use rand_distr::{Distribution, Normal};
 
 /// Simulation-backed sample source.
 ///
-/// Generates synthetic `RawSample` values from time-varying event rate profiles
+/// Generates synthetic `RawSample` values from time-varying per-thread event rate profiles
 /// (typically loaded from a sweep Perfetto trace). No hardware interaction.
 ///
 /// Unlike the old `VirtualBackend`, this does not construct fake `WireSample`
@@ -22,6 +22,8 @@ pub struct VirtualSampleSource {
     rng: StdRng,
     current_time_ns: u64,
     num_slots: usize,
+    /// Pre-computed: event_id → sorted list of tids that have data for it.
+    tids_by_event: HashMap<EventId, Vec<u32>>,
 }
 
 impl VirtualSampleSource {
@@ -36,6 +38,14 @@ impl VirtualSampleSource {
             Some(s) => StdRng::seed_from_u64(s),
             None => StdRng::from_os_rng(),
         };
+        // Pre-compute tids_by_event for efficient lookup.
+        let mut tids_by_event: HashMap<EventId, Vec<u32>> = HashMap::new();
+        for &(event_id, tid) in rates.series.keys() {
+            tids_by_event.entry(event_id).or_default().push(tid);
+        }
+        for tids in tids_by_event.values_mut() {
+            tids.sort_unstable();
+        }
         Self {
             rates,
             noise_stddev,
@@ -44,6 +54,7 @@ impl VirtualSampleSource {
             rng,
             current_time_ns: 0,
             num_slots,
+            tids_by_event,
         }
     }
 }
@@ -54,25 +65,33 @@ impl SampleSource for VirtualSampleSource {
         let ts = self.current_time_ns + self.quantum_ns;
 
         for &event_id in &self.active_set {
-            let base_rate = self.rates.rate_at(event_id, self.current_time_ns);
-            let lambda = base_rate * self.quantum_ns as f64;
-
-            let count = if lambda > 0.0 && self.noise_stddev > 0.0 {
-                let normal = Normal::new(lambda, self.noise_stddev * lambda).unwrap();
-                normal.sample(&mut self.rng).max(0.0) as u64
-            } else {
-                lambda as u64
+            let tids = match self.tids_by_event.get(&event_id) {
+                Some(t) => t.clone(),
+                None => continue,
             };
 
-            samples.push(RawSample {
-                timestamp_ns: ts,
-                duration_ns: self.quantum_ns,
-                cpu_id: 0,
-                pid: 0,
-                event_id,
-                count,
-                task: *b"simulate\0\0\0\0\0\0\0\0",
-            });
+            for tid in tids {
+                let base_rate = self.rates.rate_at(event_id, tid, self.current_time_ns);
+                let lambda = base_rate * self.quantum_ns as f64;
+
+                let count = if lambda > 0.0 && self.noise_stddev > 0.0 {
+                    let normal = Normal::new(lambda, self.noise_stddev * lambda).unwrap();
+                    normal.sample(&mut self.rng).max(0.0) as u64
+                } else {
+                    lambda as u64
+                };
+
+                samples.push(RawSample {
+                    timestamp_ns: ts,
+                    duration_ns: self.quantum_ns,
+                    cpu_id: 0,
+                    pid: 0,
+                    tid,
+                    event_id,
+                    count,
+                    task: *b"simulate\0\0\0\0\0\0\0\0",
+                });
+            }
         }
 
         self.current_time_ns = ts;
@@ -93,17 +112,18 @@ impl SampleSource for VirtualSampleSource {
     }
 }
 
-/// Per-event time-varying rates, keyed by EventId.
+/// Per-(event, thread) time-varying rates.
+/// Key: (event_id, tid). For single-threaded data, tid = 0.
 /// Each entry is a sorted Vec of (timestamp_ns, rate_events_per_ns).
 pub struct TimeVaryingRates {
-    pub series: HashMap<EventId, Vec<(u64, f64)>>,
+    pub series: HashMap<(EventId, u32), Vec<(u64, f64)>>,
 }
 
 impl TimeVaryingRates {
-    /// Return the interpolated rate for `event_id` at `time_ns`.
+    /// Return the interpolated rate for `(event_id, tid)` at `time_ns`.
     /// Holds the first/last observed rate before/after the recorded range.
-    pub fn rate_at(&self, event_id: EventId, time_ns: u64) -> f64 {
-        let Some(points) = self.series.get(&event_id) else {
+    pub fn rate_at(&self, event_id: EventId, tid: u32, time_ns: u64) -> f64 {
+        let Some(points) = self.series.get(&(event_id, tid)) else {
             return 0.0;
         };
         if points.is_empty() {

--- a/src/source/virtual_source.rs
+++ b/src/source/virtual_source.rs
@@ -65,12 +65,11 @@ impl SampleSource for VirtualSampleSource {
         let ts = self.current_time_ns + self.quantum_ns;
 
         for &event_id in &self.active_set {
-            let tids = match self.tids_by_event.get(&event_id) {
-                Some(t) => t.clone(),
-                None => continue,
+            let Some(tids) = self.tids_by_event.get(&event_id) else {
+                continue;
             };
 
-            for tid in tids {
+            for &tid in tids {
                 let base_rate = self.rates.rate_at(event_id, tid, self.current_time_ns);
                 let lambda = base_rate * self.quantum_ns as f64;
 


### PR DESCRIPTION
## Summary

- **BPF layer**: correct the TID/TGID confusion — `target_pid` renamed to `target_tgid` so process-group filtering works correctly, and the previously-padding field in `saccade_sample` now carries the actual kernel thread ID
- **Data model**: `WireSample` and `RawSample` gain a `tid` field; `TimeVaryingRates` and the virtual source key rate profiles by `(EventId, tid)` so each thread can carry its own rate curve
- **Quantum**: new `per_thread_aggregates()` applies Welford's online algorithm grouped by `(tid, EventId)`, mirroring the existing process-level aggregation
- **Perfetto writer/reader**: lazily registers process → thread → counter track hierarchies; `emit_thread_steps()` writes per-thread rate and uncertainty values; the reader uses a two-pass algorithm to resolve thread ownership via `ThreadDescriptor`, falling back to `tid=0` for older traces
- **Sinks**: `PerfettoSink` accumulates thread metadata and calls `emit_thread_steps()`; `CsvSink` adds a `tid` column
- **sweep/simulate**: sweep normalizes real OS TIDs to stable synthetic IDs by `(task_name, birth-order)` so threads align across repeated batches; simulate propagates the new `(EventId, tid)` key shape

## Test plan

- [x] `cargo build` — ensures BPF skeleton regenerates cleanly with the new `tid` field
- [x] `cargo clippy` — no new warnings
- [x] `cargo test` — unit tests pass
- [ ] `cargo run -- sweep` on a multithreaded target and open the resulting `.perfetto-trace` in the Perfetto UI — confirm per-thread counter tracks appear nested under their process track
- [ ] `cargo run -- simulate` with a sweep trace as input — confirm per-thread rate profiles are loaded and simulated correctly
- [ ] Inspect CSV output — confirm `tid` column is present and populated